### PR TITLE
Fix session start and registration bug

### DIFF
--- a/profile.php
+++ b/profile.php
@@ -1,9 +1,9 @@
 <?php
+session_start();
 if (!isset($_SESSION['user_id'])) {
     header("Location: login.php");
     exit();
 }
-session_start();
 require_once "db.php";
 
 // Lấy user_id từ URL hoặc session nếu không có

--- a/register.php
+++ b/register.php
@@ -14,14 +14,13 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
     $hash = password_hash($password, PASSWORD_DEFAULT);
 
-    $stmt = $conn->prepare("INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)");
-    $stmt->bind_param("sss", $username, $email, $hash);
+    $stmt = $pdo->prepare("INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)");
 
-    if ($stmt->execute()) {
+    if ($stmt->execute([$username, $email, $hash])) {
         header("Location: login.php");
         exit();
     } else {
-        echo "Lỗi đăng ký: " . $stmt->error;
+        echo "Lỗi đăng ký.";
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- fix wrong DB handler in register.php
- start session before checks in profile.php

## Testing
- `php -l register.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6858e40a2f0483219ba5fcb381f6b3eb